### PR TITLE
fix: correctly transition from isearch to visual-replace

### DIFF
--- a/visual-replace.el
+++ b/visual-replace.el
@@ -731,7 +731,8 @@ for `visual-replace'. Replacement starts at the current point."
                 isearch-regexp-lax-whitespace)
         (setf (visual-replace-args-lax-ws-non-regexp args)
               isearch-lax-whitespace)))
-    (isearch-exit)
+    (isearch-done nil t)
+    (isearch-clean-overlays)
     (apply #'visual-replace (visual-replace-read args))))
 
 ;;;###autoload


### PR DESCRIPTION
Calling `isearch-exit` will:

1. Recursively edit the current search string if empty and if `search-nonincremental-instead` is `t`.
2. Call `exit-recursive-edit` from `isearch-done` if `isearch-recursive-edit` is `t`.

In my case, this is preventing me from switching to `visual-replace` from `isearch` because `isearch-recursive-edit` keeps getting set (which may be a different issue...).

But, in general, this appears to be the correct way to do this:

https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/isearch.el?h=57fe24961fd1df04c9df1ba790932d6545f729e8#n2404

Emacs also binds `isearch-recursive-edit` to `nil`:

https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/isearch.el?h=57fe24961fd1df04c9df1ba790932d6545f729e8#n2397

But this seems unnecessary given the above change.